### PR TITLE
fix: Shotgun multi-fire bug

### DIFF
--- a/Assets/Scripts/EnemyScript.cs
+++ b/Assets/Scripts/EnemyScript.cs
@@ -41,11 +41,13 @@ public class Enemy : MonoBehaviour
     }
 
     public void Damage(int damageAmount, Quaternion bulletRotation) {
-        health -= damageAmount;
-        if (health <= 0) {
-            Instantiate(BloodSplat, this.transform.position, bulletRotation);
-            gameController.RegisterEnemyDeath();
-            Destroy(this.gameObject);
+        if (health > 0){
+            health -= damageAmount;
+            if (health <= 0) {
+                Instantiate(BloodSplat, this.transform.position, bulletRotation);
+                gameController.RegisterEnemyDeath();
+                Destroy(this.gameObject);
+            }
         }
     }
 


### PR DESCRIPTION
Just a single line of code. 

The bug was caused by the damage funtion triggering multiple times even when the enemy has 0 health. It was quite hard to consistantly recreate the bug, so its hard to tell if I've fully fixed it, but I've not been able to recreate it since.