### PR TITLE
fix: Limit number of held weapons

### DIFF
--- a/Assets/Prefabs/Characters/Enemy.prefab
+++ b/Assets/Prefabs/Characters/Enemy.prefab
@@ -101,8 +101,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: daf1e9723a7225245bca76f34b58502a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  BloodSplat: {fileID: 1481774045222291892, guid: db5a0d9353b24504482a89a6b7ddb343, type: 3}
-  deathNoise: {fileID: 8300000, guid: 48b38569ea402044b81745e53eb96749, type: 3}
+  maxHealth: 100
+  speed: 0.06
+  rotateSpeed: 4
+  bloodSplat: {fileID: 1481774045222291892, guid: db5a0d9353b24504482a89a6b7ddb343, type: 3}
 --- !u!50 &4564020692395794932
 Rigidbody2D:
   serializedVersion: 4

--- a/Assets/Prefabs/Characters/Player.prefab
+++ b/Assets/Prefabs/Characters/Player.prefab
@@ -269,8 +269,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fcd3a722739cd0b418c1b0838b59d96f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  health: 0
-  animator: {fileID: 7881580342363779285}
+  maxHealth: 100
+  speed: 0.14
+  inventorySize: 2
+  currentHealth: 0
   deathNoise: {fileID: 8300000, guid: d0acab290b7dc114b9d37a61a40fef70, type: 3}
   hitNoise: {fileID: 8300000, guid: e26387a74bd39604c944b6d165b206c8, type: 3}
 --- !u!114 &5954684194975434499

--- a/Assets/Scripts/EnemyScript.cs
+++ b/Assets/Scripts/EnemyScript.cs
@@ -4,23 +4,28 @@ using UnityEngine;
 
 public class Enemy : MonoBehaviour
 {
-    private Vector3 target;
-    private GameController gameController;
-    private Pathfinder pathfinder;
-    private float speed;
-    private float rotateSpeed;
-    private Rigidbody2D rigidBody;
-    private int health;
-    private bool spawnEnded;
-    public GameObject BloodSplat;
+    // Parameters
+    [SerializeField] private int maxHealth;
+    [SerializeField] private float speed;
+    [SerializeField] private float rotateSpeed;
+
+    // Tracking
+    [HideInInspector] private int currentHealth;
+    [HideInInspector] private bool spawnEnded;
+    [HideInInspector] private Vector3 target;
+
+    // Object references
+    [SerializeField] private GameObject bloodSplat;
+    [HideInInspector] private GameController gameController;
+    [HideInInspector] private Pathfinder pathfinder;
 
     private void Start() {
-        this.speed = 0.06f;
+        // Tracking
         this.spawnEnded = false;
-        this.rotateSpeed = 4f;
-        this.health = 100;
-        this.rigidBody = GetComponent<Rigidbody2D>();
+        this.currentHealth = this.maxHealth;
         this.target = GameObject.FindGameObjectWithTag("Player").transform.position;
+
+        // Object references
         this.gameController = GameObject.Find("GameController").GetComponent<GameController>();
         this.pathfinder = GameObject.Find("GameController").GetComponent<Pathfinder>();
     }
@@ -29,7 +34,7 @@ public class Enemy : MonoBehaviour
         this.target = this.pathfinder.NextDestination(this.gameObject.transform.position);
         RotateTowardsTarget();
         if (spawnEnded == true) {
-            rigidBody.MovePosition(transform.position + transform.up * speed);
+            this.GetComponent<Rigidbody2D>().MovePosition(transform.position + transform.up * speed);
         }
     }
 
@@ -41,10 +46,10 @@ public class Enemy : MonoBehaviour
     }
 
     public void Damage(int damageAmount, Quaternion bulletRotation) {
-        if (health > 0){
-            health -= damageAmount;
-            if (health <= 0) {
-                Instantiate(BloodSplat, this.transform.position, bulletRotation);
+        if (this.currentHealth > 0){
+            this.currentHealth -= damageAmount;
+            if (this.currentHealth <= 0) {
+                Instantiate(this.bloodSplat, this.transform.position, bulletRotation);
                 gameController.RegisterEnemyDeath();
                 Destroy(this.gameObject);
             }

--- a/Assets/Scripts/UserInterface.cs
+++ b/Assets/Scripts/UserInterface.cs
@@ -59,7 +59,7 @@ public class UserInterface : MonoBehaviour
     }
 
     public void UpdateHealthBar() {
-        int health = this.player.health;
+        int health = this.player.currentHealth;
         if (health >= 0){
             float healthPercent = (float)health / (float)100;
             float newHealthPosition = healthPercent * 7.76f;


### PR DESCRIPTION
- Have limited number of held weapons, when the player tries to pickup a weapon when already holding the maximum number of weapons, their currently held weapon will be destroyed and replaced with the new weapon. The weapon limit is set on the player prefab (currently set to 2). 
- Have also restructured player and enemy prefabs to only show fields that we may want to change for balancing in the inspector, everything else is hidden
- Also fixed the bug where the assault rifle would continue firing on weapon switch

